### PR TITLE
fix missing stdbool header

### DIFF
--- a/src/icon.c
+++ b/src/icon.c
@@ -17,6 +17,7 @@
 */
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>


### PR DESCRIPTION
there was no stdbool header in `icon.c` so i just added it. now build doesnt fail.