### PR TITLE
improve gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 vendor/libgrapheme
+src/*.o
+opilion


### PR DESCRIPTION
now the index doesnt include all the build files.
made gitigignore ignore `src/*.o` and `opilion`